### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/data/feeds/json/2023-08-22.json
+++ b/data/feeds/json/2023-08-22.json
@@ -4648,7 +4648,7 @@
   },
   {
     "title": "Impermanence",
-    "url": "https://nixos.wiki/wiki/Impermanence",
+    "url": "https://wiki.nixos.org/wiki/Impermanence",
     "summary": "<a href=\"https://news.ycombinator.com/item?id=37218289\">Comments</a>",
     "publish_time": "2023-08-22 11:24:45",
     "source": {

--- a/data/feeds/json/2024-02-08.json
+++ b/data/feeds/json/2024-02-08.json
@@ -1348,7 +1348,7 @@
   },
   {
     "title": "Nix-shell shebang: run any script with arbitrary packages, self-contained",
-    "url": "https://nixos.wiki/wiki/Nix-shell_shebang",
+    "url": "https://wiki.nixos.org/wiki/Nix-shell_shebang",
     "summary": "<a href=\"https://news.ycombinator.com/item?id=39292985\">Comments</a>",
     "publish_time": "2024-02-08 03:23:01",
     "source": {

--- a/data/feeds/md/2023-08-22.md
+++ b/data/feeds/md/2023-08-22.md
@@ -490,7 +490,7 @@
 485. [Jeff Bezos on AI (1998) [video]](https://www.jessewright.com/jeff-bezos-on-ai-1998) Hacker News
 486. [Incumbents from Walmart to General Motors are fighting back against disrupters](https://www.economist.com/business/2023/08/21/americas-corporate-giants-are-getting-harder-to-topple) Hacker News
 487. [Unlocking Discord Nitro Features for Free](https://blog.0x7d0.dev/history/unlocking-discord-nitro-features-for-free/) Hacker News
-488. [Impermanence](https://nixos.wiki/wiki/Impermanence) Hacker News
+488. [Impermanence](https://wiki.nixos.org/wiki/Impermanence) Hacker News
 489. [Learn AutoHotKey by stealing my scripts](https://www.hillelwayne.com/post/ahk-scripts-project/) Hacker News
 490. [缅甸高官首度回应缅北诈骗](https://s.weibo.com/weibo?q=%23%E7%BC%85%E7%94%B8%E9%AB%98%E5%AE%98%E9%A6%96%E5%BA%A6%E5%9B%9E%E5%BA%94%E7%BC%85%E5%8C%97%E8%AF%88%E9%AA%97%23&Refer=top) 微博热搜
 491. [祥云初空超话在线牵红钱](https://s.weibo.com/weibo?q=%23%E7%A5%A5%E4%BA%91%E5%88%9D%E7%A9%BA%E8%B6%85%E8%AF%9D%E5%9C%A8%E7%BA%BF%E7%89%B5%E7%BA%A2%E9%92%B1%23&Refer=top) 微博热搜

--- a/data/feeds/md/2024-02-08.md
+++ b/data/feeds/md/2024-02-08.md
@@ -148,7 +148,7 @@
 143. [Lawsuit Accuses Anna's Archive of Hacking WorldCat, Stealing 2.2 TB Data](https://torrentfreak.com/lawsuit-accuses-annas-archive-of-hacking-worldcat-stealing-2-2-tb-data-240207/) Hacker News
 144. [JavaScript in SVGs](https://www.devdailydigest.tech/javascript-in-svgs/) Hacker News
 145. [A search engine in 80 lines of Python](https://www.alexmolas.com/2024/02/05/a-search-engine-in-80-lines.html) Hacker News
-146. [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://nixos.wiki/wiki/Nix-shell_shebang) Hacker News
+146. [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://wiki.nixos.org/wiki/Nix-shell_shebang) Hacker News
 147. [Memorizing a programming language using spaced repetition software (2013)](https://sive.rs/srs) Hacker News
 148. [Unison File Synchronizer](https://github.com/bcpierce00/unison) Hacker News
 149. [移动送福幸福接龙](https://s.weibo.com/weibo?q=%23%E7%A7%BB%E5%8A%A8%E9%80%81%E7%A6%8F%E5%B9%B8%E7%A6%8F%E6%8E%A5%E9%BE%99%23&Refer=top) 微博热搜

--- a/data/sources/hackernews/json/2023-08-22.json
+++ b/data/sources/hackernews/json/2023-08-22.json
@@ -529,7 +529,7 @@
   },
   {
     "title": "Impermanence",
-    "url": "https://nixos.wiki/wiki/Impermanence",
+    "url": "https://wiki.nixos.org/wiki/Impermanence",
     "summary": "<a href=\"https://news.ycombinator.com/item?id=37218289\">Comments</a>",
     "publish_time": "2023-08-22 11:24:45",
     "source": {

--- a/data/sources/hackernews/json/2024-02-08.json
+++ b/data/sources/hackernews/json/2024-02-08.json
@@ -232,7 +232,7 @@
   },
   {
     "title": "Nix-shell shebang: run any script with arbitrary packages, self-contained",
-    "url": "https://nixos.wiki/wiki/Nix-shell_shebang",
+    "url": "https://wiki.nixos.org/wiki/Nix-shell_shebang",
     "summary": "<a href=\"https://news.ycombinator.com/item?id=39292985\">Comments</a>",
     "publish_time": "2024-02-08 03:23:01",
     "source": {

--- a/data/sources/hackernews/md/2023-08-22.md
+++ b/data/sources/hackernews/md/2023-08-22.md
@@ -51,7 +51,7 @@
 46. [Jeff Bezos on AI (1998) [video]](https://www.jessewright.com/jeff-bezos-on-ai-1998) 
 47. [Incumbents from Walmart to General Motors are fighting back against disrupters](https://www.economist.com/business/2023/08/21/americas-corporate-giants-are-getting-harder-to-topple) 
 48. [Unlocking Discord Nitro Features for Free](https://blog.0x7d0.dev/history/unlocking-discord-nitro-features-for-free/) 
-49. [Impermanence](https://nixos.wiki/wiki/Impermanence) 
+49. [Impermanence](https://wiki.nixos.org/wiki/Impermanence) 
 50. [Learn AutoHotKey by stealing my scripts](https://www.hillelwayne.com/post/ahk-scripts-project/) 
 51. [Incumbents are fighting back against disrupters](https://www.economist.com/business/2023/08/21/americas-corporate-giants-are-getting-harder-to-topple) 
 52. [Revolutionary Electrolyzer Efficiently Converts CO2 into Renewable Propane Fuel](https://scienceswitch.com/2023/08/22/revolutionary-electrolyzer-efficiently-converts-co2-into-renewable-propane-fuel/) 

--- a/data/sources/hackernews/md/2024-02-08.md
+++ b/data/sources/hackernews/md/2024-02-08.md
@@ -24,7 +24,7 @@
 19. [Lawsuit Accuses Anna's Archive of Hacking WorldCat, Stealing 2.2 TB Data](https://torrentfreak.com/lawsuit-accuses-annas-archive-of-hacking-worldcat-stealing-2-2-tb-data-240207/) 
 20. [JavaScript in SVGs](https://www.devdailydigest.tech/javascript-in-svgs/) 
 21. [A search engine in 80 lines of Python](https://www.alexmolas.com/2024/02/05/a-search-engine-in-80-lines.html) 
-22. [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://nixos.wiki/wiki/Nix-shell_shebang) 
+22. [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://wiki.nixos.org/wiki/Nix-shell_shebang) 
 23. [Memorizing a programming language using spaced repetition software (2013)](https://sive.rs/srs) 
 24. [Unison File Synchronizer](https://github.com/bcpierce00/unison) 
 25. [Lawsuit accuses Anna's Archive of hacking WorldCat](https://torrentfreak.com/lawsuit-accuses-annas-archive-of-hacking-worldcat-stealing-2-2-tb-data-240207/) 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️